### PR TITLE
chore: Use renamed krb5-testing-tools image

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "beku.py": {
-        "branch": "main",
+        "branch": "0.0.10",
         "description": "Test suite expander for Stackable Kuttl tests.",
         "homepage": null,
         "owner": "stackabletech",
         "repo": "beku.py",
-        "rev": "1ebc9e7b70fb8ee11dfb569ae45b3bcd63666d0e",
-        "sha256": "1zg24h5wdis7cysa08r8vvbw2rpyx6fgv148i1lg54dwd3sa0h0d",
+        "rev": "fc75202a38529a4ac6776dd8a5dfee278d927f58",
+        "sha256": "152yary0p11h87yabv74jnwkghsal7lx16az0qlzrzdrs6n5v8id",
         "type": "tarball",
-        "url": "https://github.com/stackabletech/beku.py/archive/1ebc9e7b70fb8ee11dfb569ae45b3bcd63666d0e.tar.gz",
+        "url": "https://github.com/stackabletech/beku.py/archive/fc75202a38529a4ac6776dd8a5dfee278d927f58.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
-        "sha256": "0awagdjzv2fsy5v7a0wxz1hd642gsglib2gk4lnqm0iybly7kf0s",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "sha256": "0dcslr2lwfaclfl4pmbwb3yw27bnvwlqiif394d3d66vyd163dvy",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/8a3354191c0d7144db9756a74755672387b702ba.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/3e3afe5174c561dee0df6f2c2b2236990146329f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "stackable-cockpit": {
@@ -29,10 +29,10 @@
         "homepage": "https://docs.stackable.tech/management/stable/",
         "owner": "stackabletech",
         "repo": "stackable-cockpit",
-        "rev": "70049cae5ff027f7e6f0e69d0503a8bb4b751a75",
-        "sha256": "1hvxhkbbzbgb41h4mygy0fyxm9amavk4f7n8gfzy4nk6khwvlwyg",
+        "rev": "e645c5c6ce42dc4eb06e0639e696cc2607011b32",
+        "sha256": "09zfx2x3gdmpn1c2ri0z0h42qi53lg09rn54vpv90kcr33l7n4sg",
         "type": "tarball",
-        "url": "https://github.com/stackabletech/stackable-cockpit/archive/70049cae5ff027f7e6f0e69d0503a8bb4b751a75.tar.gz",
+        "url": "https://github.com/stackabletech/stackable-cockpit/archive/e645c5c6ce42dc4eb06e0639e696cc2607011b32.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/tests/templates/kuttl/kerberos-ad/kinit-client.yaml.j2
+++ b/tests/templates/kuttl/kerberos-ad/kinit-client.yaml.j2
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: client
-          image: oci.stackable.tech/sdp/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
+          image: oci.stackable.tech/stackable/krb5-testing-tools:{{ test_scenario['values']['krb5-testing-tools'] }}-stackable0.0.0-dev
           command:
             - bash
           args:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -1,6 +1,6 @@
 ---
 dimensions:
-  - name: krb5
+  - name: krb5-testing-tools
     values:
       - 1.21.1
   - name: ad-custom-samaccountname
@@ -10,7 +10,7 @@ dimensions:
 tests:
   - name: kerberos-ad
     dimensions:
-      - krb5
+      - krb5-testing-tools
       - ad-custom-samaccountname
 
 suites: []


### PR DESCRIPTION
Follows from https://github.com/stackabletech/docker-images/pull/1167

- [x] niv updates
- [x] krb5-testing-tools update
- [ ] testing